### PR TITLE
split out imports (and errors), so caller.py can run without audiotts (text to speech)

### DIFF
--- a/rtclite/app/sip/caller.py
+++ b/rtclite/app/sip/caller.py
@@ -141,12 +141,20 @@ from .client import MediaSession
 from ...std.ietf import rfc3261, rfc2396, rfc3550, rfc4566, rfc2833
 from ...common import repeated_warning, ColorizingStreamHandler, getlocaladdr, setlocaladdr, gevent_Timer as Timer
 
-try: import audiodev, audiospeex, audiotts, audioop
-except ImportError: audiodev = audiospeex = audiotts = audioop = None
+try: import audiodev
+except ImportError: audiodev = None
+
+try: import audiospeex
+except ImportError: audiospeex = None
+
+try: import audiotts
+except ImportError: audiotts = None
+
+try: import audioop
+except ImportError: audioop = None
 
 try: import speech_recognition as sr
 except ImportError: sr = None
-
 
 logger = logging.getLogger('caller')
 


### PR DESCRIPTION
Because the option is there already audiotts should not be required to run caller.py (I'm having trouble compiling py-audio with audiotts). This change prevents an import error on audiotts None-ing out audiodev.