### PR TITLE
making sip caller example to work under python3

### DIFF
--- a/rtclite/app/sip/caller.py
+++ b/rtclite/app/sip/caller.py
@@ -361,7 +361,7 @@ class Stacks(object):
         if stack.sock:
             try:
                 if self.options.use_lf: data = re.sub(r'\r\n', '\n', data)
-                if stack.transport.type == Stacks.UDP: stack.sock.sendto(data, addr)
+                if stack.transport.type == Stacks.UDP: stack.sock.sendto(data.encode('utf-8'), addr)
                 elif addr in self._conn: self._conn[addr].sendall(data)
                 elif self.allow_outbound:
                     conn = self._conn[addr] = socket.socket(type=socket.SOCK_STREAM)

--- a/rtclite/multitask.py
+++ b/rtclite/multitask.py
@@ -411,6 +411,7 @@ class FDAction(FDReady):
         self.func = func
         self.args = args
         self.kwargs = kwargs
+        self.args = [arg.encode('utf-8') if isinstance(arg, str) else arg for arg in self.args]
 
     def _eval(self):
         return self.func(*(self.args), **(self.kwargs))

--- a/rtclite/std/ietf/rfc2396.py
+++ b/rtclite/std/ietf/rfc2396.py
@@ -5,6 +5,7 @@ Various forms of addresses such as URI and SIP address.
 '''
 
 import re, socket, struct
+from functools import total_ordering
 
 def isIPv4(data):
     '''Check if the data is a dotted decimal IPv4 address or not?
@@ -54,7 +55,8 @@ def isPrivate(data):
         return a == 10 or a == 172 and 16 <= b < 32 or a == 192 and b == 168
     except:
         return False
-    
+
+@total_ordering
 class URI(object):
     '''A URI object with dynamic properties.
     Attributes and items such as scheme, user, password, host, port, 
@@ -124,10 +126,15 @@ class URI(object):
     def __hash__(self):
         '''Hash is derived from lower-case string, hence causes case insensitive match'''
         return hash(str(self).lower())
-    
-    def __cmp__(self, other):
-        '''Compare two URI objects by comparing their hash values'''
-        return cmp(str(self).lower(), str(other).lower())
+
+    def __eq__(self, other):
+        return str(self).lower() == str(other).lower()
+
+    def __ne__(self, other):
+        return str(self).lower() != str(other).lower()
+
+    def __lt__(self, other):
+        return str(self).lower() < str(other).lower()
 
     @property
     def hostPort(self):


### PR DESCRIPTION
Co-authored-by: Jakub Plonka <jakub.plonka@avigilon.com>

Contains some further porting to python3 changes. With these changes we have managed to succefully run sip caller example with server and 2 callers.
Link to example description:
https://github.com/theintencity/rtclite/blob/master/rtclite/app/sip/caller.md
Here are commands used for testing:
python -m rtclite.app.sip.server -d
python -m rtclite.app.sip.caller --listen --register --user=alice --domain=localhost --no-audio
python -m rtclite.app.sip.caller --listen --register --user=bob --domain=localhost --port=5094 --to=sip:alice@localhost --send=hello --no-audio